### PR TITLE
v0.4.0 - Defer resolveBEMModifiers to truthyStringsKeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.4.0
+- Defer `resolveBEMModifiers` to `truthyStringsKeys`.
+- **Breaking change:** Remove exported `resolveBEMModifiers` function.
+
 ## v0.3.0
 - Install [`truthy-keys`](https://www.npmjs.com/package/truthy-keys) dependency.
 - **Breaking change:** Remove exported `keys` function.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bem-helpers",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "BEM helper functions for resolving and joining block to elements and modifiers.",
   "keywords": [
     "bem",
@@ -23,7 +23,8 @@
     "build": "tsc",
     "build:watch": "tsc --watch",
     "lint": "tslint src/**/*.ts",
-    "prepublish": "npm run lint && tsc && ava",
+    "prepublish": "npm run lint && npm test",
+    "pretest": "tsc",
     "test": "ava",
     "watch": "ava --watch"
   },
@@ -31,7 +32,8 @@
     "@types/classnames": "^2.2.3",
     "@types/node": "^8.0.28",
     "classnames": "^2.2.5",
-    "truthy-keys": "^0.1.2"
+    "truthy-keys": "^0.1.2",
+    "truthy-strings-keys": "^0.2.0"
   },
   "devDependencies": {
     "ava": "^0.22.0",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,7 +3,6 @@ import test from 'ava'
 import {
 	joinBEMElement,
 	joinBEMModifiers,
-	resolveBEMModifiers,
 	toBEMClassNames,
 } from './'
 
@@ -59,105 +58,6 @@ test('joinBEMModifiers joins two modifiers to the same block or element', t => {
 	t.deepEqual(
 		joinBEMModifiers('foo', ['bar', 'baz']),
 		['foo', 'foo--bar', 'foo--baz'],
-	)
-})
-
-test('resolveBEMModifiers returns an empty array by default', t => {
-	t.deepEqual(
-		resolveBEMModifiers(),
-		[],
-	)
-})
-
-test('resolveBEMModifiers returns input string wrapped in an array', t => {
-	t.deepEqual(
-		resolveBEMModifiers('foo'),
-		['foo'],
-	)
-})
-
-test('resolveBEMModifiers splits input string by multiple spaces and newlines', t => {
-	t.deepEqual(
-		resolveBEMModifiers(' \n  foo \r\n  bar   '),
-		['foo', 'bar'],
-	)
-})
-
-test('resolveBEMModifiers returns a flat array from a nested string array', t => {
-	t.deepEqual(
-		resolveBEMModifiers([
-			'foo',
-			['bar', [
-				'baz', [
-					'qux',
-				],
-			]],
-		]),
-		['foo', 'bar', 'baz', 'qux'],
-	)
-})
-
-test('resolveBEMModifiers returns a list of keys for which their values are truthy', t => {
-	t.deepEqual(
-		resolveBEMModifiers({
-			foo: true,
-			bar: false,
-			baz: 42,
-			qux: 0,
-		}),
-		['foo', 'baz'],
-	)
-})
-
-test('resolveBEMModifiers returns unique values', t => {
-	t.deepEqual(
-		resolveBEMModifiers(['foo', 'bar', 'foo']),
-		['foo', 'bar'],
-	)
-})
-
-test('resolveBEMModifiers omits falsey and non-string values', t => {
-	const values = [
-		'',
-		[],
-		'foo',
-		true,
-		false,
-		42,
-		undefined,
-		void 0,
-	]
-	t.deepEqual(
-		// tslint:disable-next-line:no-any
-		resolveBEMModifiers(values as any),
-		['foo'],
-	)
-})
-
-test('resolveBEMModifiers returns a simple flat array from a complex nested structure', t => {
-	const nested = [
-		'foo', [
-			{
-				bar: true,
-				baz: null,
-			},
-		],
-		'qux',
-		[
-			[
-				[
-					{
-						corge: undefined,
-						garpley: -1,
-					},
-				],
-			],
-		],
-	]
-	t.deepEqual(
-		// tslint:disable-next-line:no-any
-		resolveBEMModifiers(nested as any),
-		['foo', 'bar', 'qux', 'garpley'],
 	)
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import * as classNames from 'classnames'
 import truthyKeys from 'truthy-keys'
+import truthyStringsKeys, { compact } from 'truthy-strings-keys'
 
 import { BEMModifiers } from './types'
 
@@ -42,20 +43,6 @@ export function joinBEMModifiers(
 }
 
 /**
- * Resolves a simple string or a potentially deeply nested structure of
- * modifier values into a simple string array.
- * @return Returns a simple string array of modifiers that passed resolution.
- */
-export function resolveBEMModifiers(modifiers?: BEMModifiers): string[] {
-	return uniq(compact(isArray(modifiers)
-		? flatten(modifiers.map(m => resolveBEMModifiers(m)))
-		: isString(modifiers)
-			? modifiers.split(/\s+/)
-			: truthyKeys(modifiers as {}),
-	))
-}
-
-/**
  * Joins a BEM block or element with any number of modifiers. Preserves
  * existing className, if provided.
  * @param blockOrElement BEM block or element name.
@@ -69,34 +56,11 @@ export function toBEMClassNames(
 ) {
 	const joined = joinBEMModifiers(
 		blockOrElement,
-		resolveBEMModifiers(modifiers),
+		truthyStringsKeys(modifiers),
 	)
 	return classNames(compact(
 		joined.concat(className.split(/\s+/)),
 	).join(' '))
-}
-
-export function compact<T>(arr: T[]) {
-	return isArray(arr) ? arr.filter(identity) : []
-}
-
-export function flatten<T>(arr: T[]) {
-	// tslint:disable-next-line:no-any
-	return (arr || []).reduce((a, b) => a.concat(b as any), [])
-}
-
-export function identity<T>(value: T) {
-	return value
-}
-
-// tslint:disable-next-line:no-any
-export function isArray(x: any): x is any[] {
-	return Array.isArray(x)
-}
-
-// tslint:disable-next-line:no-any
-export function isString(x: any): x is string {
-	return typeof x === 'string'
 }
 
 export function pickBy<T>(obj: T) {
@@ -105,16 +69,6 @@ export function pickBy<T>(obj: T) {
 		result[key] = obj[key]
 	})
 	return result
-}
-
-export function uniq<T>(arr: T[]) {
-	return arr.filter(
-		// tslint:disable-next-line:no-any
-		function(this: any, a: T) {
-			return !this[a] ? this[a] = true : false
-		},
-		{},
-	)
 }
 
 export {


### PR DESCRIPTION
## v0.4.0
- Defer `resolveBEMModifiers` to `truthyStringsKeys`.
- **Breaking change:** Remove exported `resolveBEMModifiers` function.