### PR TITLE
v0.5.0 - Restore previously-exported functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.5.0
+- Restore `resolveBEMModifiers` function as alias to `truthyStringsKeys`.
+- Restore other previously-exported functions (`compact`, `flatten`, `identity`, `isArray`, `isString`, `uniq`).
+
 ## v0.4.0
 - Defer `resolveBEMModifiers` to `truthyStringsKeys`.
 - **Breaking change:** Remove exported `resolveBEMModifiers` function.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bem-helpers",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "BEM helper functions for resolving and joining block to elements and modifiers.",
   "keywords": [
     "bem",

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,15 @@ export function joinBEMModifiers(
 }
 
 /**
+ * Resolves a simple string or a potentially deeply nested structure of
+ * modifier values into a simple string array.
+ * @return Returns a simple string array of modifiers that passed resolution.
+ */
+export function resolveBEMModifiers(modifiers?: BEMModifiers): string[] {
+	return truthyStringsKeys(modifiers)
+}
+
+/**
  * Joins a BEM block or element with any number of modifiers. Preserves
  * existing className, if provided.
  * @param blockOrElement BEM block or element name.
@@ -56,7 +65,7 @@ export function toBEMClassNames(
 ) {
 	const joined = joinBEMModifiers(
 		blockOrElement,
-		truthyStringsKeys(modifiers),
+		resolveBEMModifiers(modifiers),
 	)
 	return classNames(compact(
 		joined.concat(className.split(/\s+/)),
@@ -76,3 +85,12 @@ export {
 	BEMModifiers,
 	BEMModifiersHash,
 } from './types'
+
+export {
+	compact,
+	flatten,
+	identity,
+	isArray,
+	isString,
+	uniq,
+} from 'truthy-strings-keys'


### PR DESCRIPTION
## v0.5.0
- Restore `resolveBEMModifiers` function as alias to `truthyStringsKeys`.
- Restore other previously-exported functions (`compact`, `flatten`, `identity`, `isArray`, `isString`, `uniq`).