### PR TITLE
v0.6.2 - Remove dependency on classnames and truthy-keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.6.2
+- Remove dependency on [`classnames`](https://www.npmjs.com/package/classnames) and [`truthy-keys`](https://www.npmjs.com/package/truthy-keys).
+
 ## v0.6.0
 - Export `BEMModifiers`, `BEMModifier` and `BEMModifiersHash` types.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bem-helpers",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "BEM helper functions for resolving and joining block to elements and modifiers.",
   "keywords": [
     "bem",
@@ -35,8 +35,6 @@
   "dependencies": {
     "@types/classnames": "^2.2.3",
     "@types/node": "^8.0.28",
-    "classnames": "^2.2.5",
-    "truthy-keys": "^0.1.2",
     "truthy-strings-keys": "^0.2.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import * as classNames from 'classnames'
-import truthyKeys from 'truthy-keys'
 import truthyStringsKeys, {
 	compact,
 	Primitives,
@@ -49,9 +47,10 @@ export function joinBEMModifiers(
 }
 
 /**
- * Resolves a simple string or a potentially deeply nested structure of
- * modifier values into a simple string array.
- * @return Returns a simple string array of modifiers that passed resolution.
+ * Alias of truthyStringsKeys. Resolves a simple string or a potentially deeply
+ * nested structure of modifier values into a simple string array.
+ * @return Returns a newly-created, flat string array of modifiers that
+ * passed resolution.
  */
 export function resolveBEMModifiers(modifiers?: BEMModifiers): string[] {
 	return truthyStringsKeys(modifiers)
@@ -73,17 +72,9 @@ export function toBEMClassNames(
 		blockOrElement,
 		resolveBEMModifiers(modifiers),
 	)
-	return classNames(compact(
+	return compact(
 		joined.concat(className.split(/\s+/)),
-	).join(' '))
-}
-
-export function pickBy<T>(obj: T) {
-	const result = {}
-	truthyKeys(obj).forEach(key => {
-		result[key] = obj[key]
-	})
-	return result
+	).join(' ')
 }
 
 export {


### PR DESCRIPTION
## v0.6.2
- Remove dependency on [`classnames`](https://www.npmjs.com/package/classnames) and [`truthy-keys`](https://www.npmjs.com/package/truthy-keys).