### PR TITLE
V0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.7.0
+- **Breaking change:** Rename `toBEMClassNames` to `deepJoinBEMModifiers` and have it return an array instead of a string. Follow with `.join(' ')` to preserve previous functionality.
+
 ## v0.6.2
 - Remove dependency on [`classnames`](https://www.npmjs.com/package/classnames) and [`truthy-keys`](https://www.npmjs.com/package/truthy-keys).
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ npm install bem-helpers
 
 ## Usage
 
-### `joinBEMElement`
+### `joinBEMElement( block, element [, separator] )`
 
 Joins a BEM block to an element.
 
@@ -45,7 +45,7 @@ joinBEMElement('foo', 'bar', '__custom__');
 // "foo__custom__bar"
 ```
 
-### `joinBEMModifiers`
+### `joinBEMModifiers( blockOrElement, modifiers [, separator] )`
 
 Joins a BEM block or element to any number of modifiers.
 
@@ -57,7 +57,7 @@ joinBEMModifiers('foo', ['bar'], '--custom--');
 // foo foo--custom--bar
 ```
 
-### `resolveBEMModifiers`
+### `resolveBEMModifiers( modifiers )`
 
 Resolves a simple string or a potentially deeply nested structure of modifier
 values into a simple string array.
@@ -85,22 +85,24 @@ resolveBEMModifiers([
 // ["foo", "bar", "qux", "garpley"]
 ```
 
-### `toBEMClassNames`
+### `deepJoinBEMModifiers( blockOrElement [, modifiers] [, options] )`
 
 ```ts
-toBEMClassNames(
-  'foo',
+const modifiers = [
+  'bar',
   [
-    'bar',
-    [
-      {
-        baz: true,
-      },
-    ],
+    {
+      bar: true,
+      baz: true,
+    },
   ],
-  'qux',
-);
-// "foo foo--bar foo--baz qux"
+];
+
+deepJoinBEMModifiers('foo', modifiers);
+// ["foo, "foo--bar", "foo--bar", "foo--baz"]
+
+deepJoinBEMModifiers('foo', modifiers, { unique: true });
+// ["foo", "foo--bar", "foo--baz"]
 ```
 
 See [the tests](https://github.com/jedmao/bem-helpers/blob/master/src/index.test.ts)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bem-helpers",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "BEM helper functions for resolving and joining block to elements and modifiers.",
   "keywords": [
     "bem",
@@ -35,7 +35,7 @@
   "dependencies": {
     "@types/classnames": "^2.2.3",
     "@types/node": "^8.0.28",
-    "truthy-strings-keys": "^0.2.0"
+    "truthy-strings-keys": "^0.3.0"
   },
   "devDependencies": {
     "ava": "^0.22.0",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,7 +3,7 @@ import test from 'ava'
 import {
 	joinBEMElement,
 	joinBEMModifiers,
-	toBEMClassNames,
+	deepJoinBEMModifiers,
 } from './'
 
 test('joinBEMElement throws if no block is provided', t => {
@@ -61,30 +61,23 @@ test('joinBEMModifiers joins two modifiers to the same block or element', t => {
 	)
 })
 
-test('toBEMClassNames returns block (first arg) when only block is provided', t => {
-	t.is(
-		toBEMClassNames('foo'),
-		'foo',
+test('deepJoinBEMModifiers returns block (first arg) when only block is provided', t => {
+	t.deepEqual(
+		deepJoinBEMModifiers('foo'),
+		['foo'],
 	)
 })
 
-test('toBEMClassNames returns joined BEM class names', t => {
-	t.is(
-		toBEMClassNames('foo', ['bar']),
-		'foo foo--bar',
+test('deepJoinBEMModifiers returns joined BEM class names', t => {
+	t.deepEqual(
+		deepJoinBEMModifiers('foo', ['bar']),
+		['foo', 'foo--bar'],
 	)
 })
 
-test('toBEMClassNames returns joined BEM class names combined with existing class names', t => {
-	t.is(
-		toBEMClassNames('foo', ['bar'], 'baz'),
-		'foo foo--bar baz',
-	)
-})
-
-test('toBEMClassNames resolves nested modifiers structure', t => {
-	t.is(
-		toBEMClassNames(
+test('deepJoinBEMModifiers resolves nested modifiers structure', t => {
+	t.deepEqual(
+		deepJoinBEMModifiers(
 			'foo',
 			[
 				'bar',
@@ -94,8 +87,26 @@ test('toBEMClassNames resolves nested modifiers structure', t => {
 					},
 				],
 			],
-			'qux',
 		),
-		'foo foo--bar foo--baz qux',
+		['foo', 'foo--bar', 'foo--baz'],
+	)
+})
+
+test('deepJoinBEMModifiers removes duplicates when { unique: true }', t => {
+	const modifiers = [
+		'bar',
+		[
+			{
+				bar: true,
+			},
+		],
+	]
+	t.deepEqual(
+		deepJoinBEMModifiers('foo', modifiers),
+		['foo', 'foo--bar', 'foo--bar'],
+	)
+	t.deepEqual(
+		deepJoinBEMModifiers('foo', modifiers, { unique: true }),
+		['foo', 'foo--bar'],
 	)
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,4 @@
-import truthyStringsKeys, {
-	compact,
-	Primitives,
-} from 'truthy-strings-keys'
+import truthyStringsKeys, { Primitives } from 'truthy-strings-keys'
 
 /**
  * BEM modifiers for blocks and elements (supports nested structures).
@@ -52,29 +49,37 @@ export function joinBEMModifiers(
  * @return Returns a newly-created, flat string array of modifiers that
  * passed resolution.
  */
-export function resolveBEMModifiers(modifiers?: BEMModifiers): string[] {
-	return truthyStringsKeys(modifiers)
+export function resolveBEMModifiers(
+	modifiers?: BEMModifiers,
+	options: {
+		unique: boolean
+	} = {
+		unique: false,
+	}): string[] {
+	return truthyStringsKeys(modifiers, options)
 }
 
 /**
- * Joins a BEM block or element with any number of modifiers. Preserves
- * existing className, if provided.
+ * Joins a BEM block or element with any number of modifiers.
  * @param blockOrElement BEM block or element name.
  * @param modifiers BEM modifiers (nested structure supported).
- * @param className Existing class name.
  */
-export function toBEMClassNames(
+export function deepJoinBEMModifiers(
 	blockOrElement: string,
 	modifiers?: BEMModifiers,
-	className: string = '',
+	options: {
+		/**
+		 * Removes duplicates.
+		 */
+		unique: boolean
+	} = {
+		unique: false,
+	},
 ) {
-	const joined = joinBEMModifiers(
+	return joinBEMModifiers(
 		blockOrElement,
-		resolveBEMModifiers(modifiers),
+		resolveBEMModifiers(modifiers, options),
 	)
-	return compact(
-		joined.concat(className.split(/\s+/)),
-	).join(' ')
 }
 
 export {


### PR DESCRIPTION
## v0.7.0
- **Breaking change:** Rename `toBEMClassNames` to `deepJoinBEMModifiers` and have it return an array instead of a string. Follow with `.join(' ')` to preserve previous functionality.