### PR TITLE
v0.8.0 - Add separator option to deepJoinBEMModifiers, more jsdoc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.8.0
+- Add `separator` option to `deepJoinBEMModifiers`.
+- Add more jsdoc comments.
+
 ## v0.7.0
 - **Breaking change:** Rename `toBEMClassNames` to `deepJoinBEMModifiers` and have it return an array instead of a string. Follow with `.join(' ')` to preserve previous functionality.
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,11 @@ const modifiers = [
 deepJoinBEMModifiers('foo', modifiers);
 // ["foo, "foo--bar", "foo--bar", "foo--baz"]
 
-deepJoinBEMModifiers('foo', modifiers, { unique: true });
-// ["foo", "foo--bar", "foo--baz"]
+deepJoinBEMModifiers('foo', modifiers, {
+  separator: '--custom--',
+  unique: true
+});
+// ["foo", "foo--custom--bar", "foo--custom--baz"]
 ```
 
 See [the tests](https://github.com/jedmao/bem-helpers/blob/master/src/index.test.ts)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bem-helpers",
-  "version": "0.7.0",
-  "description": "BEM helper functions for resolving and joining block to elements and modifiers.",
+  "version": "0.8.0",
+  "description": "BEM helper functions for resolving and joining blocks to elements, blocks to modifiers and elements to modifiers.",
   "keywords": [
     "bem",
     "helpers",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -75,6 +75,15 @@ test('deepJoinBEMModifiers returns joined BEM class names', t => {
 	)
 })
 
+test('deepJoinBEMModifiers supports custom separator option', t => {
+	t.deepEqual(
+		deepJoinBEMModifiers('foo', ['bar'], {
+			separator: '--custom--',
+		}),
+		['foo', 'foo--custom--bar'],
+	)
+})
+
 test('deepJoinBEMModifiers resolves nested modifiers structure', t => {
 	t.deepEqual(
 		deepJoinBEMModifiers(

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,17 @@ export type BEMModifiers = Primitives
  * @param element The BEM element on the right side of the join.
  */
 export function joinBEMElement(
+	/**
+	 * BEM block.
+	 */
 	block: string,
+	/**
+	 * BEM element.
+	 */
 	element: string,
+	/**
+	 * Appears between the BEM block and element (e.g., block__element).
+	 */
 	separator: string = '__',
 ) {
 	if (!block) {
@@ -32,8 +41,18 @@ export function joinBEMElement(
  * "bar" modifier. The first value is always the block or element by itself.
  */
 export function joinBEMModifiers(
+	/**
+	 * BEM block or element.
+	 */
 	blockOrElement: string,
+	/**
+	 * BEM modifiers.
+	 */
 	modifiers: string[] = [],
+	/**
+	 * Appears between the BEM block or element and each modifier
+	 * (e.g., block--modifier, block__element--modifier).
+	 */
 	separator: string = '--',
 ) {
 	return !modifiers
@@ -50,13 +69,19 @@ export function joinBEMModifiers(
  * passed resolution.
  */
 export function resolveBEMModifiers(
+	/**
+	 * BEM modifiers (supports nested structures).
+	 */
 	modifiers?: BEMModifiers,
-	options: {
-		unique: boolean
-	} = {
-		unique: false,
-	}): string[] {
-	return truthyStringsKeys(modifiers, options)
+	{
+		unique = false,
+	}: {
+		/**
+		 * Removes duplicates.
+		 */
+		unique?: boolean
+	} = {}): string[] {
+	return truthyStringsKeys(modifiers, { unique })
 }
 
 /**
@@ -65,20 +90,33 @@ export function resolveBEMModifiers(
  * @param modifiers BEM modifiers (nested structure supported).
  */
 export function deepJoinBEMModifiers(
+	/**
+	 * BEM block or element.
+	 */
 	blockOrElement: string,
+	/**
+	 * BEM modifiers.
+	 */
 	modifiers?: BEMModifiers,
-	options: {
+	{
+		separator,
+		unique = false,
+	}: {
+		/**
+		 * Appears between the BEM block or element and each modifier
+		 * (e.g., block--modifier, block__element--modifier).
+		 */
+		separator?: string
 		/**
 		 * Removes duplicates.
 		 */
-		unique: boolean
-	} = {
-		unique: false,
-	},
+		unique?: boolean
+	} = {},
 ) {
 	return joinBEMModifiers(
 		blockOrElement,
-		resolveBEMModifiers(modifiers, options),
+		resolveBEMModifiers(modifiers, { unique }),
+		separator,
 	)
 }
 


### PR DESCRIPTION
## v0.8.0
- Add `separator` option to `deepJoinBEMModifiers`.
- Add more jsdoc comments.