### PR TITLE
v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.9.0
+- Clean up dependencies.
+- Export options interfaces.
+- **Breaking change:** Stop exporting helper functions from `truthy-strings-keys` (`compact`, `flatten`, `identity`, `isArray`, `isString`, `uniq`). Sorry to be wishy washy about this one, but you should probably just import `truthy-strings-keys` directly if you want access to them.
+
 ## v0.8.1
 - Update docs.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bem-helpers",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "BEM helper functions for resolving and joining blocks to elements, blocks to modifiers and elements to modifiers.",
   "keywords": [
     "bem",
@@ -33,9 +33,7 @@
     "watch": "ava --watch"
   },
   "dependencies": {
-    "@types/classnames": "^2.2.3",
-    "@types/node": "^8.0.28",
-    "truthy-strings-keys": "^0.3.0"
+    "truthy-strings-keys": "^0.4.0"
   },
   "devDependencies": {
     "ava": "^0.22.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
-import truthyStringsKeys, { Primitives } from 'truthy-strings-keys'
+import truthyStringsKeys, {
+	Primitives,
+	TruthyStringsKeysOptions,
+} from 'truthy-strings-keys'
 
 /**
  * BEM modifiers for blocks and elements (supports nested structures).
@@ -62,6 +65,9 @@ export function joinBEMModifiers(
 		))
 }
 
+export interface ResolveBEMModifiersOptions
+extends TruthyStringsKeysOptions {}
+
 /**
  * Creates a flat string array from a potentially deeply nested structure of
  * modifiers.
@@ -73,13 +79,17 @@ export function resolveBEMModifiers(
 	modifiers?: BEMModifiers,
 	{
 		unique = false,
-	}: {
-		/**
-		 * Removes duplicates.
-		 */
-		unique?: boolean
-	} = {}): string[] {
+	}: ResolveBEMModifiersOptions = {}): string[] {
 	return truthyStringsKeys(modifiers, { unique })
+}
+
+export interface DeepJoinBEMModifiersOptions
+extends ResolveBEMModifiersOptions {
+	/**
+	 * Appears between the BEM block or element and each modifier
+	 * (e.g., block--modifier, block__element--modifier).
+	 */
+	separator?: string
 }
 
 /**
@@ -99,17 +109,7 @@ export function deepJoinBEMModifiers(
 	{
 		separator,
 		unique = false,
-	}: {
-		/**
-		 * Appears between the BEM block or element and each modifier
-		 * (e.g., block--modifier, block__element--modifier).
-		 */
-		separator?: string
-		/**
-		 * Removes duplicates.
-		 */
-		unique?: boolean
-	} = {},
+	}: DeepJoinBEMModifiersOptions = {},
 ) {
 	return joinBEMModifiers(
 		blockOrElement,
@@ -119,12 +119,6 @@ export function deepJoinBEMModifiers(
 }
 
 export {
-	compact,
-	flatten,
-	identity,
-	isArray,
-	isString,
 	Primitive as BEMModifier,
 	PrimitiveHash as BEMModifiersHash,
-	uniq,
 } from 'truthy-strings-keys'


### PR DESCRIPTION
## v0.9.0
- Clean up dependencies.
- Export options interfaces.
- **Breaking change:** Stop exporting helper functions from `truthy-strings-keys` (`compact`, `flatten`, `identity`, `isArray`, `isString`, `uniq`). Sorry to be wishy washy about this one, but you should probably just import `truthy-strings-keys` directly if you want access to them.