### PR TITLE
v1.0.0 - Remove support for deeply nested modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v1.0.0
+- **Breaking:** Remove support for deeply nested modifiers (decided this limitation was actually a good thing).
+  - Removed `resolveBEMModifiers`
+  - Removed `deepJoinBEMModifiers`
+- **Breaking:** Changed modifiers argument to receive an object hash instead of a string array.
+  - before: `joinBEMModifiers('foo__bar', ['baz', 'qux']);`
+  - after: `joinBEMModifiers('foo__bar', { baz: true, qux: true });`
+- **Breaking:** No longer exporting `BEMModifier` and `BEMModifiersHash` interfaces. Instead, use the new `BEMModifiers` interface, which represents a shallow hash object.
+
 ## v0.9.1
 - Disable sourcemaps for distribution.
 - Fix tslint.

--- a/README.md
+++ b/README.md
@@ -51,64 +51,11 @@ joinBEMElement('foo', 'bar', '__custom__');
 Joins a BEM block or element to any number of modifiers.
 
 ```ts
-joinBEMModifiers('foo__bar', ['baz', 'qux']);
+joinBEMModifiers('foo__bar', { baz: true, qux: true });
 // "foo__bar foo__bar--baz foo__bar--qux"
 
-joinBEMModifiers('foo', ['bar'], '--custom--');
+joinBEMModifiers('foo', { bar: true }, '--custom--');
 // foo foo--custom--bar
-```
-
-### `resolveBEMModifiers( modifiers )`
-
-Creates a flat string array from a potentially deeply nested structure of
-modifiers.
-
-```ts
-resolveBEMModifiers([
-  'foo', [
-    {
-      bar: true,
-      baz: null,
-    },
-  ],
-  'qux',
-  [
-    [
-      [
-        {
-          corge: undefined,
-          garpley: -1,
-        },
-      ],
-    ],
-  ],
-]);
-// ["foo", "bar", "qux", "garpley"]
-```
-
-### `deepJoinBEMModifiers( blockOrElement [, modifiers] [, options] )`
-
-Joins a BEM block or element with any number of modifiers.
-
-```ts
-const modifiers = [
-  'bar',
-  [
-    {
-      bar: true,
-      baz: true,
-    },
-  ],
-];
-
-deepJoinBEMModifiers('foo', modifiers);
-// ["foo, "foo--bar", "foo--bar", "foo--baz"]
-
-deepJoinBEMModifiers('foo', modifiers, {
-  separator: '--custom--',
-  unique: true
-});
-// ["foo", "foo--custom--bar", "foo--custom--baz"]
 ```
 
 See [the tests](https://github.com/jedmao/bem-helpers/blob/master/src/index.test.ts)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bem-helpers",
-  "version": "0.9.1",
+  "version": "1.0.0",
   "description": "BEM helper functions for resolving and joining blocks to elements, blocks to modifiers and elements to modifiers.",
   "keywords": [
     "bem",
@@ -34,9 +34,6 @@
     "test": "ava",
     "watch": "npm test -- --watch",
     "prepack": "npm test"
-  },
-  "dependencies": {
-    "truthy-strings-keys": "^0.4.3"
   },
   "devDependencies": {
     "ava": "^0.24.0",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,7 +3,6 @@ import test from 'ava'
 import {
 	joinBEMElement,
 	joinBEMModifiers,
-	deepJoinBEMModifiers,
 } from './'
 
 test('joinBEMElement throws if no block is provided', t => {
@@ -42,80 +41,21 @@ test('joinBEMElement joins a block to an element with a custom separator', t => 
 
 test('joinBEMModifiers joins with "--" by default', t => {
 	t.deepEqual(
-		joinBEMModifiers('foo', ['bar']),
+		joinBEMModifiers('foo', { bar: true }),
 		['foo', 'foo--bar'],
 	)
 })
 
 test('joinBEMModifiers joins with a custom separator', t => {
 	t.deepEqual(
-		joinBEMModifiers('foo', ['bar'], '--custom--'),
+		joinBEMModifiers('foo', { bar: true }, '--custom--'),
 		['foo', 'foo--custom--bar'],
 	)
 })
 
 test('joinBEMModifiers joins two modifiers to the same block or element', t => {
 	t.deepEqual(
-		joinBEMModifiers('foo', ['bar', 'baz']),
+		joinBEMModifiers('foo', { bar: true, baz: true }),
 		['foo', 'foo--bar', 'foo--baz'],
-	)
-})
-
-test('deepJoinBEMModifiers returns block (first arg) when only block is provided', t => {
-	t.deepEqual(
-		deepJoinBEMModifiers('foo'),
-		['foo'],
-	)
-})
-
-test('deepJoinBEMModifiers returns joined BEM class names', t => {
-	t.deepEqual(
-		deepJoinBEMModifiers('foo', ['bar']),
-		['foo', 'foo--bar'],
-	)
-})
-
-test('deepJoinBEMModifiers supports custom separator option', t => {
-	t.deepEqual(
-		deepJoinBEMModifiers('foo', ['bar'], {
-			separator: '--custom--',
-		}),
-		['foo', 'foo--custom--bar'],
-	)
-})
-
-test('deepJoinBEMModifiers resolves nested modifiers structure', t => {
-	t.deepEqual(
-		deepJoinBEMModifiers(
-			'foo',
-			[
-				'bar',
-				[
-					{
-						baz: true,
-					},
-				],
-			],
-		),
-		['foo', 'foo--bar', 'foo--baz'],
-	)
-})
-
-test('deepJoinBEMModifiers removes duplicates when { unique: true }', t => {
-	const modifiers = [
-		'bar',
-		[
-			{
-				bar: true,
-			},
-		],
-	]
-	t.deepEqual(
-		deepJoinBEMModifiers('foo', modifiers),
-		['foo', 'foo--bar', 'foo--bar'],
-	)
-	t.deepEqual(
-		deepJoinBEMModifiers('foo', modifiers, { unique: true }),
-		['foo', 'foo--bar'],
 	)
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,9 @@
-import truthyStringsKeys, {
-	Primitives,
-	TruthyStringsKeysOptions,
-} from 'truthy-strings-keys'
-
 /**
- * BEM modifiers for blocks and elements (supports nested structures).
+ * BEM modifiers for blocks and elements.
  */
-export type BEMModifiers = Primitives
+export type BEMModifiers = {
+	[modifierName: string]: boolean
+}
 
 /**
  * Joins a BEM block with an element.
@@ -36,89 +33,51 @@ export function joinBEMElement(
 	return [block, element].join(separator)
 }
 
-/**
- * Joins a block or element with any number of modifiers.
- * @param blockOrElement The block or element on the left side of each join.
- * @param modifiers The modifiers on the right side of each join.
- * @return Returns at least 2 values (e.g., ['foo', 'foo--bar'] for a single
- * "bar" modifier. The first value is always the block or element by itself.
- */
-export function joinBEMModifiers(
-	/**
-	 * BEM block or element.
-	 */
-	blockOrElement: string,
-	/**
-	 * BEM modifiers.
-	 */
-	modifiers: string[] = [],
-	/**
-	 * Appears between the BEM block or element and each modifier
-	 * (e.g., block--modifier, block__element--modifier).
-	 */
-	separator: string = '--',
-) {
-	return !modifiers
-		? [blockOrElement]
-		: [blockOrElement].concat(modifiers.map(
-			m => [blockOrElement, m].join(separator),
-		))
+export interface JoinBlockToModifiers {
+	(
+		/**
+		 * The BEM block on the left side of each join.
+		 */
+		block: string,
+		/**
+		 * If specified, the last class names returned will be the BEM block name followed by any number of modifiers provided (e.g., foo--mod1 foo--mod2).
+		 */
+		modifiers: BEMModifiers,
+		/**
+		 * Appears between the BEM block or element and each modifier (i.e., the "--" in foo--mod).
+		 */
+		separator?: string,
+	): string[]
 }
 
-export interface ResolveBEMModifiersOptions
-extends TruthyStringsKeysOptions {}
-
-/**
- * Creates a flat string array from a potentially deeply nested structure of
- * modifiers.
- */
-export function resolveBEMModifiers(
-	/**
-	 * BEM modifiers (supports nested structures).
-	 */
-	modifiers?: BEMModifiers,
-	{
-		unique = false,
-	}: ResolveBEMModifiersOptions = {}): string[] {
-	return truthyStringsKeys(modifiers, { unique })
-}
-
-export interface DeepJoinBEMModifiersOptions
-extends ResolveBEMModifiersOptions {
-	/**
-	 * Appears between the BEM block or element and each modifier
-	 * (e.g., block--modifier, block__element--modifier).
-	 */
-	separator?: string
+export interface JoinElementToModifiers {
+	(
+		/**
+		 * The BEM element on the left side of each join.
+		 */
+		element: string,
+		/**
+		 * If specified, the last class names returned will be the BEM element name followed by any number of modifiers provided (e.g., foo__bar--mod1 foo__bar--mod2).
+		 */
+		modifiers: BEMModifiers,
+		/**
+		 * Appears between the BEM element and each modifier (i.e., the "--" in foo__bar--mod).
+		 */
+		separator?: string,
+	): string[]
 }
 
 /**
  * Joins a BEM block or element with any number of modifiers.
- * @param blockOrElement BEM block or element name.
- * @param modifiers BEM modifiers (nested structure supported).
  */
-export function deepJoinBEMModifiers(
-	/**
-	 * BEM block or element.
-	 */
+export const joinBEMModifiers: JoinBlockToModifiers & JoinElementToModifiers = (
 	blockOrElement: string,
-	/**
-	 * BEM modifiers.
-	 */
-	modifiers?: BEMModifiers,
-	{
-		separator,
-		unique = false,
-	}: DeepJoinBEMModifiersOptions = {},
-) {
-	return joinBEMModifiers(
-		blockOrElement,
-		resolveBEMModifiers(modifiers, { unique }),
-		separator,
-	)
-}
-
-export {
-	Primitive as BEMModifier,
-	PrimitiveHash as BEMModifiersHash,
-} from 'truthy-strings-keys'
+	modifiers: BEMModifiers = {},
+	separator: string = '--',
+) => (
+	[blockOrElement]
+		.concat(Object.keys(modifiers)
+			.filter(m => modifiers[m])
+			.map(m => [blockOrElement, m].join(separator)),
+		)
+)

--- a/tslint.json
+++ b/tslint.json
@@ -19,7 +19,6 @@
 		"interface-name": [true, "never-prefix"],
 		"jsdoc-format": true,
 		"label-position": true,
-		"max-line-length": [true, 120],
 		"member-ordering": [true, {
 			"order": [
 				"static-field",


### PR DESCRIPTION
## v1.0.0
- **Breaking:** Remove support for deeply nested modifiers (decided this limitation was actually a good thing).
  - Removed `resolveBEMModifiers`
  - Removed `deepJoinBEMModifiers`
- **Breaking:** Changed modifiers argument to receive an object hash instead of a string array.
  - before: `joinBEMModifiers('foo__bar', ['baz', 'qux']);`
  - after: `joinBEMModifiers('foo__bar', { baz: true, qux: true });`
- **Breaking:** No longer exporting `BEMModifier` and `BEMModifiersHash` interfaces. Instead, use the new `BEMModifiers` interface, which represents a shallow hash object.